### PR TITLE
correct login var, production not staging, strip whitespace

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,13 +4,13 @@ from launchpadlib.launchpad import Launchpad
 def no_credential():
  print("Can't proceed without Launchpad credentials.")
  sys.exit()
-launchpad = Launchpad.login_with('Mass package bug subscription adder', 'staging', credential_save_failed=no_credential)
+lp = Launchpad.login_with('Mass package bug subscription adder', 'production', credential_save_failed=no_credential)
 teamtowrite = (raw_input('What person/team would you like to use for this(ID not full name)? '))
 filepath = (raw_input('Please specify the path of the input file: '))
 with open(filepath, "r") as ins:
  filearray = []
  for line in ins:
-  filearray.append(line)
+  filearray.append(line.strip())
 for i in range(len(filearray)):
  print("Assigning:")
  print(filearray[i])


### PR DESCRIPTION
three problems existed with the code:
1. `launchpad` was used to define the login var, while the code that does the work referred to `lp`.
2. couldn't authenticate with UbuntuSSO while being on `staging`, so switched to `production`.
3. even without whitespace in the input file itself, `filearray.append(line)` was appending `line\n`, so used `strip()` to kill any whitespace.
